### PR TITLE
Mark Camunda Modeler as patched

### DIFF
--- a/electron_apps.csv
+++ b/electron_apps.csv
@@ -45,7 +45,7 @@ Buka,,,,programmatic,unknown,unknown
 Buttercup,https://github.com/buttercup/buttercup-desktop,^22.0.0,2023-10-02 22:10:03-0700,programmatic,vulnerable,vulnerable
 Cacher,,,,programmatic,unknown,unknown
 Calmly Writer,,,,programmatic,unknown,unknown
-Camunda Modeler,https://github.com/camunda/camunda-modeler/,^26.0.0,2023-10-02 22:10:04-0700,programmatic,vulnerable,vulnerable
+Camunda Modeler,https://github.com/camunda/camunda-modeler/,^26.2.4,2023-10-03 10:42:00+0200,manual,patched,patched
 canSnippet,,,,programmatic,unknown,unknown
 Caption Pro,,,,programmatic,unknown,unknown
 Caret,,,,programmatic,unknown,unknown


### PR DESCRIPTION
Camunda Modeler [v5.15.2](https://github.com/camunda/camunda-modeler/blob/develop/CHANGELOG.md#5152) used electron@26.2.4. The repository depends now on patched version of Electron explicitly.